### PR TITLE
Remove positional arguments

### DIFF
--- a/1.0/LenovoInfo.psm1
+++ b/1.0/LenovoInfo.psm1
@@ -164,9 +164,9 @@ Function Get-LenovoWarrantyInfo {
 
         if ($webresponse.SelectSingleNode("//serviceInfo")) {
 
-            $properties.Add("ShipDate", $webresponse.wiOutputForm.warrantyInfo.serviceInfo.shipDate[0])
-            $properties.Add("WarrantyStartDate", $webresponse.wiOutputForm.warrantyInfo.serviceInfo.warstart[0])
-            $properties.Add("WarrantyEndDate", $webresponse.wiOutputForm.warrantyInfo.serviceInfo.wed[0])
+            $properties.Add("ShipDate", $webresponse.wiOutputForm.warrantyInfo.serviceInfo.shipDate)
+            $properties.Add("WarrantyStartDate", $webresponse.wiOutputForm.warrantyInfo.serviceInfo.warstart)
+            $properties.Add("WarrantyEndDate", $webresponse.wiOutputForm.warrantyInfo.serviceInfo.wed)
         } else {
             $properties.Add("ShipDate", $null)
             $properties.Add("WarrantyStartDate", $null)


### PR DESCRIPTION
Was trying to utilize this module when I kept running into a issue with the returned values for dates just returning "2". By using show-object I was able to determine the REST call was getting a good response back. After seeing that the dates were actually being returned I realized the "2" that was coming back at the end was due to the positional argument being used. 

Tested by removing the [0] for shipDate, warstart, and wed on lines 167-169.